### PR TITLE
Fix for #78

### DIFF
--- a/Assets/Scripts/VR Interactions/PointerInteractor.cs
+++ b/Assets/Scripts/VR Interactions/PointerInteractor.cs
@@ -239,16 +239,7 @@ public class PointerInteractor : XRBaseInteractor, IUIInteractable
     //
     public void receiveRay(PointsCast.EventData data)
     {
-
-        if (data.IsValid)
-        {
-            m_RaycastHits[0] = data.HitData.Value;
             m_HitCount = 1;
             m_LinePoints = data.Points.ToArray<Vector3>();
-        } else
-        {
-            m_HitCount = 0;
-        }
     }
-
 }


### PR DESCRIPTION
closes #78 

removes the need for the Box Collider. 

Note - the flickering will still happen until the actual box colliders are removed but it no longer affects functionality.