### PR TITLE
Clean up EditStart and EditEnd

### DIFF
--- a/Assets/Scripts/Adapters/DataPlotter.cs
+++ b/Assets/Scripts/Adapters/DataPlotter.cs
@@ -106,14 +106,6 @@ namespace Virgis {
             throw new NotImplementedException();
         }
 
-        protected override void StartEditSession() {
-            
-        }
-
-        protected override void ExitEditSession(bool saved) {
-           
-        }
-
         public override void MoveAxis(MoveArgs args) {
             
         }

--- a/Assets/Scripts/Basic Types/Layer.cs
+++ b/Assets/Scripts/Basic Types/Layer.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace Virgis {
 
-    public interface ILayer {
+    public interface ILayer : IVirgisEntity {
         void Add(MoveArgs args);
         void Draw();
         void CheckPoint();
@@ -159,15 +159,31 @@ namespace Virgis {
         /// <summary>
         /// Called when an edit session starts
         /// </summary>
-        protected virtual void StartEditSession() {
-            // do nothing
+        public virtual void StartEditSession() {
+           // do nothing
         }
 
         /// <summary>
         /// Called when an edit session ends
         /// </summary>
         /// <param name="saved">true if stop and save, false if stop and discard</param>
-        protected virtual void ExitEditSession(bool saved) {
+        public virtual void ExitEditSession(bool saved) {
+            // do nothing
+        }
+
+        /// <summary>
+        /// called when a daughter IVirgisEntity is selected
+        /// </summary>
+        /// <param name="button"> SelectionType</param>
+        public virtual void Selected(SelectionTypes button) {
+            //do nothing
+        }
+
+        /// <summary>
+        /// Called when a daughter IVirgisEntity is UnSelected
+        /// </summary>
+        /// <param name="button">SelectionType</param>
+        public virtual void UnSelected(SelectionTypes button) {
             // do nothing
         }
 

--- a/Assets/Scripts/Basic Types/VirgisComponent.cs
+++ b/Assets/Scripts/Basic Types/VirgisComponent.cs
@@ -12,7 +12,8 @@ namespace Virgis
     {
         void Selected(SelectionTypes button);
         void UnSelected(SelectionTypes button);
-        void EditEnd();
+        void StartEditSession();
+        void ExitEditSession(bool saved);
     }
 
     /// <summary>
@@ -69,10 +70,18 @@ namespace Virgis
         public abstract void UnSelected(SelectionTypes button);
 
         /// <summary>
+        /// Called when an edit session starts
+        /// </summary>
+        public virtual void StartEditSession() { 
+            //do nothing
+        }
+
+        /// <summary>
         /// Called when an edit session ends
         /// </summary>
-        public abstract void EditEnd();
-
+        public virtual void ExitEditSession(bool saved) {
+            // do nothing
+        }
 
         /// <summary>
         /// Sent by the UI to request this component to move.

--- a/Assets/Scripts/Geometries/Dataline.cs
+++ b/Assets/Scripts/Geometries/Dataline.cs
@@ -226,10 +226,6 @@ namespace Virgis
             return result;
         }
 
-        public override void EditEnd()
-        {
-
-        }
 
         public override void MoveTo(Vector3 newPos)
         {

--- a/Assets/Scripts/Geometries/Datapoint.cs
+++ b/Assets/Scripts/Geometries/Datapoint.cs
@@ -132,10 +132,6 @@ namespace Virgis
             }
         }
 
-        public override void EditEnd()
-        {
-
-        }
 
         public override void MoveAxis(MoveArgs args)
         {

--- a/Assets/Scripts/Geometries/Datapolygon.cs
+++ b/Assets/Scripts/Geometries/Datapolygon.cs
@@ -87,10 +87,6 @@ namespace Virgis
             Shape.GetComponent<Renderer>().material.SetColor("_BaseColor", newCol);
         }
 
-        public override void EditEnd()
-        {
-
-        }
 
         public override void MoveTo(Vector3 newPos)
         {

--- a/Assets/Scripts/Geometries/LineSegment.cs
+++ b/Assets/Scripts/Geometries/LineSegment.cs
@@ -80,13 +80,6 @@ namespace Virgis
             transform.localScale = new Vector3(diameter / linescale.x, diameter / linescale.y, length);
         }
 
-        /// <summary>
-        /// Callled on an ExitEditSession event
-        /// </summary>
-        public override void EditEnd()
-        {
-
-        }
 
         public override void Translate(MoveArgs args)
         {

--- a/Assets/Scripts/Layers/LineLayer.cs
+++ b/Assets/Scripts/Layers/LineLayer.cs
@@ -124,11 +124,6 @@ namespace Virgis
             };
         }
 
-        protected override void ExitEditSession(bool saved)
-        {
-            BroadcastMessage("EditEnd", SendMessageOptions.DontRequireReceiver);
-        }
-
         protected override void _checkpoint() { }
 
         protected override void _save()

--- a/Assets/Scripts/Layers/PointLayer.cs
+++ b/Assets/Scripts/Layers/PointLayer.cs
@@ -118,11 +118,6 @@ namespace Virgis
             };
         }
 
-        protected override void ExitEditSession(bool saved)
-        {
-            BroadcastMessage("EditEnd", SendMessageOptions.DontRequireReceiver);
-        }
-
         protected override void _checkpoint() { }
         protected override void _save()
         {

--- a/Assets/Scripts/Layers/PolygonLayer.cs
+++ b/Assets/Scripts/Layers/PolygonLayer.cs
@@ -181,11 +181,6 @@ namespace Virgis
             };
         }
 
-        protected override void ExitEditSession(bool saved)
-        {
-            BroadcastMessage("EditEnd", SendMessageOptions.DontRequireReceiver);
-        }
-
         protected override void _checkpoint() { }
         protected override void _save()
         {
@@ -228,10 +223,5 @@ namespace Virgis
         {
             changed = true;
         }
-
-        /*public override VirgisComponent GetClosest(Vector3 coords)
-        {
-            throw new System.NotImplementedException();
-        }*/
     }
 }

--- a/Assets/Scripts/MapInitialize.cs
+++ b/Assets/Scripts/MapInitialize.cs
@@ -43,8 +43,8 @@ namespace Virgis {
                 print("instantiate app state");
                 appState = Instantiate(appState);
             }
-            appState.AddStartEditSessionListener(StartEditSession);
-            appState.AddEndEditSessionListener(ExitEditSession);
+            appState.AddStartEditSessionListener(_onStartEditSession);
+            appState.AddEndEditSessionListener(_onExitEditSession);
         }
 
         /// 
@@ -130,7 +130,7 @@ namespace Virgis {
 
 
 
-        protected override void ExitEditSession(bool saved) {
+        public override void ExitEditSession(bool saved) {
             if (saved) {
                 Save();
             } else {
@@ -163,8 +163,20 @@ namespace Virgis {
 
         }
 
-        protected override void StartEditSession() {
+        public override void StartEditSession() {
             CheckPoint();
+        }
+
+        protected void _onStartEditSession() {
+            BroadcastMessage("StartEditSession", SendMessageOptions.DontRequireReceiver);
+        }
+
+        /// <summary>
+        /// Called when an edit session ends
+        /// </summary>
+        /// <param name="saved">true if stop and save, false if stop and discard</param>
+        protected void _onExitEditSession(bool saved) {
+            BroadcastMessage("ExitEditSession", saved, SendMessageOptions.DontRequireReceiver);
         }
     }
 }


### PR DESCRIPTION
closes #136 

There was a lot of inconsistency about calling various edit session lifecycle hooks and this was hiding one bug that prevent start edit from being called.

I tidied everything up to set of methods on a root IVirgisEntity interface and called them all from event listeners in MapInitilaize