### PR TITLE
Fix for #126

### DIFF
--- a/Assets/Prefabs/Label.prefab
+++ b/Assets/Prefabs/Label.prefab
@@ -137,6 +137,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -210,6 +211,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Scripts/Basic Types/typings.cs
+++ b/Assets/Scripts/Basic Types/typings.cs
@@ -22,6 +22,9 @@ namespace Virgis
         public float scale; // OPTIONAL change in scale to apply to target
     }
 
+    /// <summary>
+    /// Enum holding the types of "selection"tha the user can make
+    /// </summary>
     public enum SelectionTypes
     {
         SELECT,     // Select a sing;le vertex
@@ -31,21 +34,41 @@ namespace Virgis
 
     public static class PositionExtensionMethods
     {
+        /// <summary>
+        /// Converts Iposition to Vector2D
+        /// </summary>
+        /// <param name="position">IPosition</param>
+        /// <returns>Mapbox.Utils.Vector2d</returns>
         public static Mapbox.Utils.Vector2d Vector2d(this IPosition position)
         {
             return new Mapbox.Utils.Vector2d((float)position.Latitude, (float)position.Longitude);
         }
 
+        /// <summary>
+        /// Converts IPosition to UnityEngine.vector2
+        /// </summary>
+        /// <param name="position">IPosition</param>
+        /// <returns>UnityEngine.Vector2</returns>
         public static Vector2 Vector2(this IPosition position)
         {
             return new Vector2((float)position.Latitude, (float)position.Longitude);
         }
 
+        /// <summary>
+        /// Converts IPositon to Position
+        /// </summary>
+        /// <param name="position"></param>
+        /// <returns></returns>
         public static Position Point(this IPosition position)
         {
             return position as Position;
         }
 
+        /// <summary>
+        /// Converts Iposition to Vector3
+        /// </summary>
+        /// <param name="position">IPosition</param>
+        /// <returns>Vector3</returns>
         public static Vector3 Vector3(this IPosition position)
         {
             return Tools.Ipos2Vect(position as Position);
@@ -54,11 +77,22 @@ namespace Virgis
 
     public static class LineExtensionMethods
     {
+        /// <summary>
+        /// Converts LineString Vertex i to a Position
+        /// </summary>
+        /// <param name="line">LineString</param>
+        /// <param name="i">vertex index</param>
+        /// <returns>Position</returns>
         public static Position Point(this LineString line, int i)
         {
             return line.Coordinates[i] as Position;
         }
 
+        /// <summary>
+        /// Converts LineString to Position[]
+        /// </summary>
+        /// <param name="line">LineString</param>
+        /// <returns>Position[]</returns>
         public static Position[] Points(this LineString line)
         {
             ReadOnlyCollection<IPosition> data = line.Coordinates;
@@ -73,6 +107,12 @@ namespace Virgis
 
     public static class DcurveExtensions
     {
+        /// <summary>
+        /// Creates g3.DCurve from Vector3[]
+        /// </summary>
+        /// <param name="curve">DCurve</param>
+        /// <param name="verteces">Vextor3[]</param>
+        /// <param name="bClosed">whether the line is closed</param>
         public static void Vector3(this g3.DCurve3 curve, Vector3[] verteces, bool bClosed)
         {
             curve.Closed = bClosed;
@@ -82,6 +122,11 @@ namespace Virgis
             }
         }
 
+        /// <summary>
+        /// Converts a DCurve into Vector3[]
+        /// </summary>
+        /// <param name="curve">DCurve</param>
+        /// <returns>Vector3[]</returns>
         public static Vector3d Center(this DCurve3 curve)
         {
             Vector3d center = Vector3d.Zero;
@@ -95,6 +140,11 @@ namespace Virgis
             return center;
         }
 
+        /// <summary>
+        /// Estimates the 3D Centroid of a 3d SCurve
+        /// </summary>
+        /// <param name="curve">g3.DCurve</param>
+        /// <returns>g3.Vector3d Centroid</returns>
         public static Vector3d CenterMark(this DCurve3 curve)
         {
             _ = curve.DistanceSquared(curve.Center(), out int iSeg, out double tangent);
@@ -107,6 +157,11 @@ namespace Virgis
 
     public static class SimpleMeshExtensions
     {
+        /// <summary>
+        /// Converts g3.SimpleMesh to UnityEngine.Mesh
+        /// </summary>
+        /// <param name="simpleMesh">SimpleMesh</param>
+        /// <returns>UnityEngine.Mesh</returns>
         public static Mesh ToMesh(this SimpleMesh simpleMesh)
         {
             Mesh unityMesh = new Mesh();
@@ -143,6 +198,12 @@ namespace Virgis
 
     public static class VirgisVectorExtensions
     {
+        /// <summary>
+        /// Rounds a Vector3 in 3d to the nearest value divisible by roundTo
+        /// </summary>
+        /// <param name="vector3">Vector 3 value</param>
+        /// <param name="roundTo"> rounding size</param>
+        /// <returns>Vector3 rounded value</returns>
         public static Vector3 Round(this Vector3 vector3, float roundTo = 0.1f)
         {
             return new Vector3(
@@ -153,6 +214,9 @@ namespace Virgis
         }
     }
 
+    /// <summary>
+    /// Structure used to hold avertex for an arbitrary shape and to calculate equality
+    /// </summary>
     public class VertexLookup
     {
         public Guid Id;

--- a/Assets/Scripts/Geometries/Dataline.cs
+++ b/Assets/Scripts/Geometries/Dataline.cs
@@ -121,17 +121,15 @@ namespace Virgis
             {
                 if (!(i + 1 == line.Length && Lr))
                 {
-                    GameObject handle = Instantiate(HandlePrefab, vertex, Quaternion.identity);
+                    GameObject handle = Instantiate(HandlePrefab, vertex, Quaternion.identity, transform );
                     VirgisComponent com = handle.GetComponent<VirgisComponent>();
-                    handle.transform.parent = transform;
                     VertexTable.Add(new VertexLookup() { Id = com.id, Vertex = i, isVertex = true, Com = com });
                     com.SetColor ((Color)symbology["point"].Color);
                     handle.transform.localScale = symbology["point"].Transform.Scale;
                 }
                 if (i + 1 != line.Length)
                 {
-                    GameObject lineSegment = Instantiate(CylinderObject, vertex, Quaternion.identity);
-                    lineSegment.transform.parent = transform;
+                    GameObject lineSegment = Instantiate(CylinderObject, vertex, Quaternion.identity, transform);
                     LineSegment com = lineSegment.GetComponent<LineSegment>();
                     com.Draw(vertex, line[i + 1], i, i + 1, symbology["line"].Transform.Scale.magnitude);
                     com.SetColor((Color)symbology["line"].Color);
@@ -143,9 +141,8 @@ namespace Virgis
             //Set the label
             if (LabelPrefab != null)
             {
-                GameObject labelObject = Instantiate(LabelPrefab, center, Quaternion.identity);
-                labelObject.transform.parent = transform;
-                labelObject.transform.Translate(Vector3.up * symbology["line"].Transform.Scale.magnitude);
+                GameObject labelObject = Instantiate(LabelPrefab, center, Quaternion.identity, transform);
+                labelObject.transform.Translate(transform.TransformVector(Vector3.up) * symbology["line"].Transform.Scale.magnitude, Space.Self);
                 label = labelObject.transform;
                 Text labelText = labelObject.GetComponentInChildren<Text>();
                 if (symbology["line"].ContainsKey("Label") && symbology["line"].Label != null && gisProperties.ContainsKey(symbology["line"].Label))

--- a/Assets/Scripts/Layers/LineLayer.cs
+++ b/Assets/Scripts/Layers/LineLayer.cs
@@ -110,8 +110,7 @@ namespace Virgis
 
                 foreach (LineString line in mLines.Coordinates)
                 {
-                    GameObject dataLine = Instantiate(LinePrefab, Tools.Ipos2Vect(line.Point(0)), Quaternion.identity);
-                    dataLine.transform.parent = gameObject.transform;
+                    GameObject dataLine = Instantiate(LinePrefab, transform, false);
 
                     //set the gisProject properties
                     Dataline com = dataLine.GetComponent<Dataline>();

--- a/Assets/Scripts/Layers/PointLayer.cs
+++ b/Assets/Scripts/Layers/PointLayer.cs
@@ -7,6 +7,8 @@ using GeoJSON.Net;
 using System.Threading.Tasks;
 using Project;
 using UnityEngine.UI;
+using Zinnia.Extension;
+using System.Reflection.Emit;
 
 namespace Virgis
 {
@@ -86,8 +88,7 @@ namespace Virgis
                     Vector3 position = Tools.Ipos2Vect(in_position);
 
                     //instantiate the prefab with coordinates defined above
-                    GameObject dataPoint = Instantiate(PointPrefab, new Vector3(0, 0, 0), Quaternion.identity);
-                    dataPoint.transform.parent = gameObject.transform;
+                    GameObject dataPoint = Instantiate(PointPrefab, transform, false);
 
                     // add the gis data from geoJSON
                     Datapoint com = dataPoint.GetComponent<Datapoint>();
@@ -105,8 +106,8 @@ namespace Virgis
                     }
 
                     //Set the label
-                    GameObject labelObject = Instantiate(LabelPrefab, Vector3.zero, Quaternion.identity);
-                    labelObject.transform.parent = dataPoint.transform;
+                    GameObject labelObject = Instantiate(LabelPrefab,  dataPoint.transform, false);
+                    labelObject.transform.localScale = labelObject.transform.localScale * Vector3.one.magnitude / dataPoint.transform.localScale.magnitude;
                     labelObject.transform.localPosition = Vector3.up * displacement;
                     Text labelText = labelObject.GetComponentInChildren<Text>();
 
@@ -149,11 +150,5 @@ namespace Virgis
         {
 
         }
-
-        /*public override VirgisComponent GetClosest(Vector3 coords)
-        {
-            throw new System.NotImplementedException();
-        }*/
-
     }
 }

--- a/Assets/Scripts/Layers/PolygonLayer.cs
+++ b/Assets/Scripts/Layers/PolygonLayer.cs
@@ -140,12 +140,9 @@ namespace Virgis
                     }
 
                     //Create the GameObjects
-                    GameObject dataLine = Instantiate(LinePrefab, center, Quaternion.identity);
-                    GameObject dataPoly = Instantiate(PolygonPrefab, center, Quaternion.identity);
-                    GameObject centroid = Instantiate(HandlePrefab, center, Quaternion.identity);
-                    dataPoly.transform.parent = gameObject.transform;
-                    dataLine.transform.parent = dataPoly.transform;
-                    centroid.transform.parent = dataLine.transform;
+                    GameObject dataPoly = Instantiate(PolygonPrefab, center, Quaternion.identity, transform);
+                    GameObject dataLine = Instantiate(LinePrefab,  dataPoly.transform, false);
+                    GameObject centroid = Instantiate(HandlePrefab,  dataLine.transform, false);
 
                     // add the gis data from geoJSON
                     Datapolygon com = dataPoly.GetComponent<Datapolygon>();
@@ -157,9 +154,8 @@ namespace Virgis
                     if (symbology["body"].ContainsKey("Label") && properties.ContainsKey(symbology["body"].Label))
                     {
                         //Set the label
-                        GameObject labelObject = Instantiate(LabelPrefab, center, Quaternion.identity);
-                        labelObject.transform.parent = centroid.transform;
-                        labelObject.transform.Translate(Vector3.up * symbology["point"].Transform.Scale.magnitude);
+                        GameObject labelObject = Instantiate(LabelPrefab, centroid.transform, false );
+                        labelObject.transform.Translate(centroid.transform.TransformVector(Vector3.up) * symbology["point"].Transform.Scale.magnitude, Space.Self);
                         Text labelText = labelObject.GetComponentInChildren<Text>();
                         labelText.text = (string)properties[symbology["body"].Label];
                     }

--- a/Assets/Scripts/tools.cs
+++ b/Assets/Scripts/tools.cs
@@ -8,6 +8,11 @@ namespace Virgis {
 
     public class Tools {
 
+        /// <summary>
+        /// Converts Position to Vector in World Space taking account of zoom, scale and map scale
+        /// </summary>
+        /// <param name="position">Position</param>
+        /// <returns>Vector3 World Space Location</returns>
         static public Vector3 Ipos2Vect(Position position) {
             float Alt;
             if (position.Altitude == null) {
@@ -15,11 +20,16 @@ namespace Virgis {
             } else {
                 Alt = (float) position.Altitude * AppState.instance.abstractMap.WorldRelativeScale;
             };
-            Vector3 _world = Conversions.GeoToWorldPosition(position.Latitude, position.Longitude, AppState.instance.abstractMap.CenterMercator, AppState.instance.abstractMap.WorldRelativeScale).ToVector3xz();
-            _world.y = Alt;
-            return _world;
+            Vector3 mapLocal = Conversions.GeoToWorldPosition(position.Latitude, position.Longitude, AppState.instance.abstractMap.CenterMercator, AppState.instance.abstractMap.WorldRelativeScale).ToVector3xz();
+            mapLocal.y = Alt;
+            return AppState.instance.map.transform.TransformPoint(mapLocal);
         }
 
+        /// <summary>
+        /// Converts LineString to Vector3[] in world space taking account of zoom, scale and map scale
+        /// </summary>
+        /// <param name="line">LineString</param>
+        /// <returns>Vector3[] World Space Locations</returns>
         static public Vector3[] LS2Vect(LineString line) {
             Vector3[] result = new Vector3[line.Coordinates.Count];
             for (int i = 0; i < line.Coordinates.Count; i++) {
@@ -28,6 +38,11 @@ namespace Virgis {
             return result;
         }
 
+        /// <summary>
+        /// Convert Vector3 World Space location to Position taking account of zoom, scale and mapscale
+        /// </summary>
+        /// <param name="position">Vector3 World Space coordinates</param>
+        /// <returns>Position</returns>
         static public IPosition Vect2Ipos(Vector3 position) {
             Vector3 mapLocal = AppState.instance.map.transform.InverseTransformPoint(position);
             Vector2d _latlng = VectorExtensions.GetGeoPosition(mapLocal, AppState.instance.abstractMap.CenterMercator, AppState.instance.abstractMap.WorldRelativeScale);


### PR DESCRIPTION
closes #126 

The _draw functions made a number of hidden assumptions about scale that caused the features to be drawn in the wrong place if there was a scale or zoom.

Also, there was a bug in Tools that was obscured by the lack of comments - so intended function was not clear. So have also commented all of Tools and Typings