### PR TITLE
#166

### DIFF
--- a/Assets/Scripts/Basic Types/typings.cs
+++ b/Assets/Scripts/Basic Types/typings.cs
@@ -168,7 +168,7 @@ namespace Virgis
         }
 
         /// <summary>
-        /// Converts a DCurve into Vector3[]
+        /// Estimates the 3D centroid of a DCurve 
         /// </summary>
         /// <param name="curve">DCurve</param>
         /// <returns>Vector3[]</returns>
@@ -186,7 +186,7 @@ namespace Virgis
         }
 
         /// <summary>
-        /// Estimates the 3D Centroid of a 3d SCurve
+        /// Estimates the nearest point on a DCurve to the centroid of that DCurve
         /// </summary>
         /// <param name="curve">g3.DCurve</param>
         /// <returns>g3.Vector3d Centroid</returns>

--- a/Assets/Scripts/FeatureAdder.cs
+++ b/Assets/Scripts/FeatureAdder.cs
@@ -115,8 +115,10 @@ namespace Virgis {
                         if (_newFeature != null ) {
                             if (_lastVertex.Count == 1) {
                                 _newFeature.transform.GetComponentInChildren<Dataline>().AddVertex(posWhenSinglePress);
+                                (_newFeature as Datapolygon).ResetCenter();
                             } else {
                                 _lastVertex.RemoveAt(0);
+                                (_newFeature as Datapolygon).ResetCenter();
                             }
                             
                         } else {

--- a/Assets/Scripts/Geometries/Datapolygon.cs
+++ b/Assets/Scripts/Geometries/Datapolygon.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using GeoJSON.Net.Geometry;
 using System;
 using System.Runtime.InteropServices;
+using g3;
 
 namespace Virgis
 {
@@ -220,22 +221,16 @@ namespace Virgis
             return triangles;
         }
 
-        public static Vector3 FindCenter(Vector3[] poly)
-        {
-            Vector3 center = Vector3.zero;
-            foreach (Vector3 v3 in poly)
-            {
-                center += v3;
-            }
-            return center / poly.Length;
-        }
 
         /// <summary>
         /// Reset the center vertex to be the center of the Linear Ring vertexes
         /// </summary>
         public void ResetCenter() {
-            Datapoint centroid = VertexTable.Find(item => item.Vertex == -1).Com as Datapoint;
-            
+            VertexLookup centroid = VertexTable.Find(item => item.Vertex == -1);
+            DCurve3 curve = new DCurve3();
+            curve.Vector3(GetVertexPositions(), true);
+            centroid.Com.transform.position = (Vector3)curve.Center();
+            MakeMesh();
         }
 
         static Vector2[] BuildUVs(Vector3[] vertices)
@@ -309,6 +304,10 @@ namespace Virgis
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Get an array of the Datapoint components for the vertexes
+        /// </summary>
+        /// <returns> Datapoint[]</returns>
         public Datapoint[] GetVertexes() {
             Datapoint[] result = new Datapoint[VertexTable.Count - 1];
             for (int i = 0; i < result.Length; i++) {
@@ -316,6 +315,11 @@ namespace Virgis
             }
             return result;
         }
+
+    
+        public Vector3[] GetVertexPositions() {
+            return GetComponentInChildren<Dataline>().GetVertexPositions();
+        }
     }
-    }
+}
 

--- a/Assets/Scripts/Layers/PolygonLayer.cs
+++ b/Assets/Scripts/Layers/PolygonLayer.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.SocialPlatforms.GameCenter;
 using UnityEngine.UI;
+using g3;
 
 namespace Virgis {
 
@@ -105,8 +106,10 @@ namespace Virgis {
             bodyMain.SetColor("_BaseColor", body);
         }
 
-        protected override VirgisComponent _addFeature(Vector3[] geometry) {;
-            return _drawFeature(geometry, Datapolygon.FindCenter(geometry));
+        protected override VirgisComponent _addFeature(Vector3[] geometry) {
+            DCurve3 curve = new DCurve3();
+            curve.Vector3(geometry, true);
+            return _drawFeature(geometry, (Vector3)curve.Center());
         }
 
         protected override void _draw() {
@@ -138,7 +141,9 @@ namespace Virgis {
                             center = (properties["polyhedral"] as Point).Coordinates.Vector3();
                         }
                     } else {
-                        center = Datapolygon.FindCenter(poly);
+                        DCurve3 curve = new DCurve3();
+                        curve.Vector3(poly, true);
+                        center = (Vector3)curve.Center();
                         properties["polyhedral"] = center.ToPoint();
                     }
                     _drawFeature(poly, center, gisId, properties as Dictionary<string, object>);


### PR DESCRIPTION
Fixes the problem with the polygon centroid when adding a new Polygon by updating the centroid and mesh after each new vertex.

Note - this PR requires the changes to FeatureAdder for polygons and is therefore raised against the budi branch